### PR TITLE
Add composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "vadimonus-report/extendedlog",
+    "type": "moodle-report",
+    "require": {
+        "composer/installers": "^2.1"
+    },
+    "authors": [
+        {
+            "name": "Vadim Dvorovenko",
+            "email": "vadimon@mail.ru"
+        }
+    ]
+}


### PR DESCRIPTION
Add composer so that the plugin is copied to the [correct directory when installed with composer](https://github.com/composer/installers/blob/main/src/Composer/Installers/MoodleInstaller.php#L55).